### PR TITLE
More grammar

### DIFF
--- a/grammar/__tests__/uspto.test.js
+++ b/grammar/__tests__/uspto.test.js
@@ -100,4 +100,15 @@ describe('USPTO Grammar', () => {
 		testValidInput('"chocolate pie"^100')
 		testValidInput('"chocolate pie"^100 AND walnuts')
 	})
+
+	it('should allow for wildcard operators', () => {
+		testValidInput('banana$')
+		testValidInput('banana$15')
+		testValidInput('"apple dumplings"$10')
+		testValidInput('"apple dumplings"$10 AND parrots')
+		testValidInput('banana$15 ADJ muffins$5')
+		testValidInput('banana$15 ADJ5 muffins$5')
+		testValidInput('banana$15 ADJ5 muffins$5 #why not test comments again')
+		testValidInput('banana$15 15')
+	})
 })

--- a/grammar/__tests__/uspto.test.js
+++ b/grammar/__tests__/uspto.test.js
@@ -111,4 +111,11 @@ describe('USPTO Grammar', () => {
 		testValidInput('banana$15 ADJ5 muffins$5 #why not test comments again')
 		testValidInput('banana$15 15')
 	})
+
+	it('should allow for line number clauses', () => {
+		testValidInput('L15')
+		testValidInput('banana L15')
+		testValidInput('L15 OR "pants"')
+		testValidInput('L15 OR L16')
+	})
 })

--- a/grammar/__tests__/uspto.test.js
+++ b/grammar/__tests__/uspto.test.js
@@ -69,11 +69,21 @@ describe('USPTO Grammar', () => {
 
 	it('should parse proximity clauses', () => {
 		testValidInput('banana NEAR tree')
+		testValidInput('banana ONEAR tree')
 		testValidInput('banana ADJ tree')
 		testValidInput('banana WITH tree')
 		testValidInput('banana SAME tree')
 		testValidInput('"banana tree" SAME island')
 		testValidInput('(banana SAME tree) AND ("jumping" ADJ "jacks")')
+	})
+
+	it('should parse modified proximity clauses', () => {
+		testValidInput('banana NEAR15 tree')
+		testValidInput('banana ONEAR15 tree')
+		testValidInput('banana ADJ15 tree')
+		testValidInput('banana SAME15 tree')
+		testValidInput('"banana tree" SAME15 island')
+		testValidInput('(banana SAME2 tree) AND ("jumping" ADJ3 "jacks")')
 	})
 
 	it('should parse clauses with numbers', () => {

--- a/grammar/__tests__/uspto.test.js
+++ b/grammar/__tests__/uspto.test.js
@@ -94,4 +94,10 @@ describe('USPTO Grammar', () => {
 		testValidInput('"banana soup"~7')
 		testValidInput('"banana soup"~7 AND "pumpkin pie"~3 AND ice cream')
 	})
+
+	it('should allow boost operators', () => {
+		testValidInput('banana^4')
+		testValidInput('"chocolate pie"^100')
+		testValidInput('"chocolate pie"^100 AND walnuts')
+	})
 })

--- a/grammar/__tests__/uspto.test.js
+++ b/grammar/__tests__/uspto.test.js
@@ -88,4 +88,10 @@ describe('USPTO Grammar', () => {
 		testValidInput('PRAN/somebody')
 		testValidInput('ART/"ONCE TOLD ME THE WORLD" # WAS GONNA ROLL ME')
 	})
+
+	it('should allow fuzzy operators', () => {
+		testValidInput('banana~4')
+		testValidInput('"banana soup"~7')
+		testValidInput('"banana soup"~7 AND "pumpkin pie"~3 AND ice cream')
+	})
 })

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -13,6 +13,7 @@
 		fuzzyOperator: '~',
 		boostOperator: '^',
 		wildcard: /\$\d*/,
+		lineNumber: /L\d*/,
 		leftParen: '(',
 		rightParen: ')',
 		extensionOperator: '.',
@@ -58,6 +59,7 @@ terms -> (
 	| fieldClause _
 	| fuzzyClause _
 	| boostClause _
+	| lineClause _
 ):+
 
 atomicTerm ->
@@ -113,6 +115,11 @@ boostClause -> atomicTerm %boostOperator %number
 # ‘$‘ will be interpreted as any number of characters
 # ‘$n’ will be interpreted as n number of characters
 wildcardClause -> atomicTerm %wildcard
+
+#################
+## Line Clause ##
+# Line numbers used in search text will be of the form L followed by the line number
+lineClause -> %lineNumber
 
 #######################
 ## Boolean Operators ##

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -12,13 +12,14 @@
 		andOperator: '&', // An alternative to "AND"
 		fuzzyOperator: '~',
 		boostOperator: '^',
+		wildcard: /\$\d*/,
 		leftParen: '(',
 		rightParen: ')',
 		extensionOperator: '.',
 		fieldOperator: '/',
 		term: [
 			{
-				match: /[^\s"#\|&()\d\.\/~\^]+/,
+				match: /[^\s"#\|&()\d\.\/~\^\$]+/,
 				type: moo.keywords({
 					booleanOperator: ['OR', 'AND', 'NOT', 'XOR'],
 					proximityOperator: ['ADJ','NEAR','WITH','SAME'],
@@ -63,6 +64,7 @@ atomicTerm ->
 	  %term
 	| %literal
 	| %number
+	| wildcardClause
 
 ##############
 ## Comments ##
@@ -105,6 +107,12 @@ fuzzyClause -> atomicTerm %fuzzyOperator %number
 # ‘^’ if used in search text will always have a number following ‘^’
 # and this number will be used as ‘BOOST’ value for the string preceding ‘^’.
 boostClause -> atomicTerm %boostOperator %number
+
+##################
+## Wildcard Clause ##
+# ‘$‘ will be interpreted as any number of characters
+# ‘$n’ will be interpreted as n number of characters
+wildcardClause -> atomicTerm %wildcard
 
 #######################
 ## Boolean Operators ##

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -23,7 +23,7 @@
 				match: /[^\s"#\|&()\d\.\/~\^\$]+/,
 				type: moo.keywords({
 					booleanOperator: ['OR', 'AND', 'NOT', 'XOR'],
-					proximityOperator: ['ADJ','NEAR','WITH','SAME'],
+					proximityOperator: ['ADJ','NEAR', 'ONEAR', 'WITH','SAME'],
 					field: [
 						'ATT', 'AT', 'KD', 'PARN', 'SRC', 'PDID', 'PD', 'PRAN', 'PRN', 'PRCO', 'PRC', 'PRAD',
 						'PRD', 'PRAY', 'PRY', 'RLAN', 'RLPN', 'ART', 'UNIT', 'ASCI', 'ASCO', 'ASCC', 'ASTX', 'ASST',
@@ -140,12 +140,14 @@ booleanOperator ->
 # Proximity operators make it possible to compare distance between terms
 # - ADJ: TermA next to TermB in the order specified in the same sentence.
 # - NEAR: next to Terms in any order in the same sentence.
+# - ONEAR: same as NEAR but order matters
 # - WITH: TermA in the same sentence with TermB.
 # - SAME: TermA in the same paragraph with Terms
 #
 # You can also modify distances for some proximity clauses
 # - ADJn: TermA within n terms of Bin the order specified in the same sentence.
 # - NEARn: TermA within n terms of B in any order in the same sentence.
+# - ONEARn: same as NEARn but order matters
 # - SAMEn: TermA within n paragraphs of TermB
 # where "n" is a number
 proximityOperator ->

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -10,13 +10,14 @@
 		unpairedQuote: '"', // To be treated as whitespace
 		orOperator: '|', // An alternative to "OR"
 		andOperator: '&', // An alternative to "AND"
+		fuzzyOperator: '~',
 		leftParen: '(',
 		rightParen: ')',
 		extensionOperator: '.',
 		fieldOperator: '/',
 		term: [
 			{
-				match: /[^\s"#\|&()\d\.\/]+/,
+				match: /[^\s"#\|&()\d\.\/~]+/,
 				type: moo.keywords({
 					booleanOperator: ['OR', 'AND', 'NOT', 'XOR'],
 					proximityOperator: ['ADJ','NEAR','WITH','SAME'],
@@ -53,6 +54,7 @@ terms -> (
 	| closedClause _
 	| proximityClause _
 	| fieldClause _
+	| fuzzyClause _
 ):+
 
 atomicTerm ->
@@ -88,6 +90,13 @@ fieldClause ->
 
 extension -> atomicTerm %extensionOperator %field
 flag -> %field %fieldOperator atomicTerm
+
+##################
+## Fuzzy Clause ##
+# ‘~’ if used in search text will always have a number following ‘~’
+# and  will be interpreted as ‘FUZZY’ of the preceding string with a
+# similarity of the following number.
+fuzzyClause -> atomicTerm %fuzzyOperator %number
 
 #######################
 ## Boolean Operators ##

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -11,13 +11,14 @@
 		orOperator: '|', // An alternative to "OR"
 		andOperator: '&', // An alternative to "AND"
 		fuzzyOperator: '~',
+		boostOperator: '^',
 		leftParen: '(',
 		rightParen: ')',
 		extensionOperator: '.',
 		fieldOperator: '/',
 		term: [
 			{
-				match: /[^\s"#\|&()\d\.\/~]+/,
+				match: /[^\s"#\|&()\d\.\/~\^]+/,
 				type: moo.keywords({
 					booleanOperator: ['OR', 'AND', 'NOT', 'XOR'],
 					proximityOperator: ['ADJ','NEAR','WITH','SAME'],
@@ -55,6 +56,7 @@ terms -> (
 	| proximityClause _
 	| fieldClause _
 	| fuzzyClause _
+	| boostClause _
 ):+
 
 atomicTerm ->
@@ -97,6 +99,12 @@ flag -> %field %fieldOperator atomicTerm
 # and  will be interpreted as ‘FUZZY’ of the preceding string with a
 # similarity of the following number.
 fuzzyClause -> atomicTerm %fuzzyOperator %number
+
+##################
+## Boost Clause ##
+# ‘^’ if used in search text will always have a number following ‘^’
+# and this number will be used as ‘BOOST’ value for the string preceding ‘^’.
+boostClause -> atomicTerm %boostOperator %number
 
 #######################
 ## Boolean Operators ##


### PR DESCRIPTION
This adds support for the following items:

- ~
- ^
- $ and $n
- line numbers
- ONEAR

It does not add support for field validation and date comparisons (e.g. `@ad>10102019`), which appears to be the final major requirement for this first pass.

Related to issue #3 