### PR TITLE
Initial grammar postprocessing

### DIFF
--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -81,9 +81,18 @@ terms -> (
 ):+ {% denest %}
 
 atomicTerm ->
-		%term {% denest %}
-	| %literal {% denest %}
-	| %number {% denest %}
+		%term {% ([term]) => ({
+			type: 'text',
+			content: term.text,
+		}) %}
+	| %literal {% ([literal]) => ({
+			type: 'literal',
+			content: literal.text.slice(1,-1),
+		}) %}
+	| %number {% ([number]) => ({
+			type: 'text',
+			content: number.text,
+		}) %}
 	| wildcardClause {% denest %}
 
 ##############

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -47,10 +47,14 @@
 
 @lexer lexer
 
-query -> _ clause comment:? {% data => ({
-	query: data[1],
-	comment: data[2],
-}) %}
+query ->
+	  _ clause {% data => ({
+			query: data[1],
+		}) %}
+	| _ clause comment {% data => ({
+			query: data[1],
+			comment: data[2].text,
+		}) %}
 
 clause ->
 		terms {% ([terms]) => ({

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -48,7 +48,7 @@
 @lexer lexer
 
 query ->
-	  _ clause {% data => ({
+		_ clause {% data => ({
 			query: data[1],
 		}) %}
 	| _ clause comment {% data => ({
@@ -59,7 +59,7 @@ query ->
 clause ->
 		terms {% ([terms]) => ({
 			type: 'clause',
-			content: terms
+			content: terms,
 		}) %}
 	| booleanClause
 
@@ -146,7 +146,14 @@ boostClause -> atomicTerm %boostOperator %number
 ## Wildcard Clause ##
 # ‘$‘ will be interpreted as any number of characters
 # ‘$n’ will be interpreted as n number of characters
-wildcardClause -> atomicTerm %wildcard
+wildcardClause -> atomicTerm %wildcard {% ([atomicTerm, wildcard]) => {
+	const modifier = '0' + wildcard.text.substring(1);
+	return {
+		type: 'postfix-wildcard',
+		term: atomicTerm,
+		modifier: Number.parseInt(modifier, 10),
+	}
+} %}
 
 #################
 ## Line Clause ##

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -98,7 +98,12 @@ closedClause -> %leftParen _ clause %rightParen
 ## Proximity Clauses ##
 # clauses that identify pairs of nearby terms
 proximityClause ->
-		atomicTerm _ proximityOperator __ atomicTerm
+	atomicTerm _ proximityOperator __ atomicTerm {% ([left, _1, operator, _2, right ]) => ({
+		type: 'proximityClause',
+		left,
+		operator,
+		right,
+	})%}
 
 ###################
 ## Field Clauses ##
@@ -166,8 +171,14 @@ booleanOperator ->
 # - SAMEn: TermA within n paragraphs of TermB
 # where "n" is a number
 proximityOperator ->
-		%proximityOperator {% ([operator]) => ({ operator }) %}
-	| %proximityOperator %number {% ([operator, modifier]) => ({ operator, modifier }) %}
+		%proximityOperator {% ([operator]) => ({
+			type: operator.text,
+			modifier: null
+		}) %}
+	| %proximityOperator %number {% ([operator, modifier]) => ({
+			type: operator.text,
+			modifier: modifier.text,
+		}) %}
 
 ################
 ## Whitespace ##

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -61,15 +61,14 @@ clause ->
 			type: "clause",
 			content: terms
 		}) %}
-	| terms conjunction __ clause {% ([left, conjunction, _, right]) => ({
-			type: "conjunction",
-			left,
-			conjunction,
-			right,
-		}) %}
+	| booleanClause
 
-conjunction ->
-	booleanOperator {% denest %}
+booleanClause -> terms booleanOperator __ clause {% ([left, operator, _, right]) => ({
+	type: 'booleanClause',
+	left,
+	operator,
+	right,
+}) %}
 
 terms -> (
 		atomicTerm _ {% denest %}
@@ -153,9 +152,9 @@ lineClause -> %lineNumber {% denest %}
 # - NOT
 # - XOR
 booleanOperator ->
-		%booleanOperator {% denest %}
-	| %orOperator {% denest %}
-	| %andOperator {% denest %}
+		%booleanOperator {% ([operator]) => ({ type: operator.text }) %}
+	| %orOperator {% ([operator]) => ({ type: "OR" }) %}
+	| %andOperator {% ([operator]) => ({ type: "AND" }) %}
 
 #########################
 ## Proximity Operators ##

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -12,8 +12,8 @@
 		whitespace: { match: /\s+/, lineBreaks: true },
 		number: /\d+/,
 		unpairedQuote: '"', // To be treated as whitespace
-		orOperator: '|', // An alternative to "OR"
-		andOperator: '&', // An alternative to "AND"
+		orOperator: '|', // An alternative to 'OR'
+		andOperator: '&', // An alternative to 'AND'
 		fuzzyOperator: '~',
 		boostOperator: '^',
 		wildcard: /\$\d*/,
@@ -58,7 +58,7 @@ query ->
 
 clause ->
 		terms {% ([terms]) => ({
-			type: "clause",
+			type: 'clause',
 			content: terms
 		}) %}
 	| booleanClause
@@ -153,8 +153,8 @@ lineClause -> %lineNumber {% denest %}
 # - XOR
 booleanOperator ->
 		%booleanOperator {% ([operator]) => ({ type: operator.text }) %}
-	| %orOperator {% ([operator]) => ({ type: "OR" }) %}
-	| %andOperator {% ([operator]) => ({ type: "AND" }) %}
+	| %orOperator {% ([operator]) => ({ type: 'OR' }) %}
+	| %andOperator {% ([operator]) => ({ type: 'AND' }) %}
 
 #########################
 ## Proximity Operators ##
@@ -172,7 +172,7 @@ booleanOperator ->
 # - NEARn: TermA within n terms of B in any order in the same sentence.
 # - ONEARn: same as NEARn but order matters
 # - SAMEn: TermA within n paragraphs of TermB
-# where "n" is a number
+# where 'n' is a number
 proximityOperator ->
 		%proximityOperator {% ([operator]) => ({
 			type: operator.text,


### PR DESCRIPTION
There is still  more postprocessing to add but this is a good start, and I want to merge it sooner rather than later.

This covers postprocessing for:

* boolean clauses
* comments
* atomic terms
* wildcards