### PR TITLE
Make keywords case insensitive

### DIFF
--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -6,11 +6,6 @@
 @{%
 	const moo = require('moo')
 
-	const caseInsensitiveKeywords = defs => {
-		const keywords = moo.keywords(defs)
-		return value => keywords(value.toUpperCase())
-	}
-
 	const lexer = moo.compile({
 		comment: /#.*/,
 		literal: /".*?"/, // Exact phrases can be included in double quotes
@@ -30,9 +25,15 @@
 		term: [
 			{
 				match: /[^\s"#\|&()\d\.\/~\^\$]+/,
-				type: caseInsensitiveKeywords({
-					booleanOperator: ['OR', 'AND', 'NOT', 'XOR'],
-					proximityOperator: ['ADJ','NEAR', 'ONEAR', 'WITH','SAME'],
+				type: moo.keywords({
+					booleanOperator: [
+						'OR', 'AND', 'NOT', 'XOR',
+						'or', 'and', 'not', 'xor',
+					],
+					proximityOperator: [
+						'ADJ','NEAR', 'ONEAR', 'WITH','SAME',
+						'adj','near', 'onear', 'with','same',
+					],
 					field: [
 						'ATT', 'AT', 'KD', 'PARN', 'SRC', 'PDID', 'PD', 'PRAN', 'PRN', 'PRCO', 'PRC', 'PRAD',
 						'PRD', 'PRAY', 'PRY', 'RLAN', 'RLPN', 'ART', 'UNIT', 'ASCI', 'ASCO', 'ASCC', 'ASTX', 'ASST',
@@ -43,6 +44,15 @@
 						'FRGP', 'FRCL', 'OREF', 'UREF', 'URGP', 'URCL', 'READ', 'REFD', 'REAN', 'REPD', 'REPN', 'R47X',
 						'CPC', 'URPN', 'INV', 'AD', 'FD', 'AY', 'FY', 'PPPD', 'ASGP', 'AS', 'INGP', 'IN',
 						'APNR', 'APN', 'APP', 'AP',
+						'att', 'at', 'kd', 'parn', 'src', 'pdid', 'pd', 'pran', 'prn', 'prco', 'prc', 'prad',
+						'prd', 'pray', 'pry', 'rlan', 'rlpn', 'art', 'unit', 'asci', 'asco', 'ascc', 'astx', 'asst',
+						'aszp', 'ccls', 'cor', 'ccor', 'cxr', 'ccxr', 'clas', 'icls', 'ior', 'cior', 'ixr', 'cixr',
+						'ipcc', 'ipcr', 'ipc', 'cicl', 'dd', 'fs', 'bi', 'xa', 'xp', 'gi', 'inci', 'inco',
+						'incc', 'intx', 'inst', 'insa', 'inzp', 'pn', 'did', 'isd', 'py', 'isy', 'ab', 'bsum',
+						'clm', 'detd', 'drwd', 'ti', 'ptan', 'ptad', 'pt3d', 'ptpn', 'ptpd', 'frpn', 'frco', 'fipc',
+						'frgp', 'frcl', 'oref', 'uref', 'urgp', 'urcl', 'read', 'refd', 'rean', 'repd', 'repn', 'r47x',
+						'cpc', 'urpn', 'inv', 'ad', 'fd', 'ay', 'fy', 'pppd', 'asgp', 'as', 'ingp', 'in',
+						'apnr', 'apn', 'app', 'ap',
 					],
 				}),
 			},

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -6,6 +6,11 @@
 @{%
 	const moo = require('moo')
 
+	const caseInsensitiveKeywords = defs => {
+		const keywords = moo.keywords(defs)
+		return value => keywords(value.toUpperCase())
+	}
+
 	const lexer = moo.compile({
 		comment: /#.*/,
 		literal: /".*?"/, // Exact phrases can be included in double quotes
@@ -25,7 +30,7 @@
 		term: [
 			{
 				match: /[^\s"#\|&()\d\.\/~\^\$]+/,
-				type: moo.keywords({
+				type: caseInsensitiveKeywords({
 					booleanOperator: ['OR', 'AND', 'NOT', 'XOR'],
 					proximityOperator: ['ADJ','NEAR', 'ONEAR', 'WITH','SAME'],
 					field: [


### PR DESCRIPTION
The specification dictates that keywords should be case insensitive (e.g. AND vs and).  This implements case insensitivity.

~Note: This implements the case insensitivity portion, though this implementation does technically allow for a combination of upper and lower case even though that is explicitly mentioned as not being necessary.  If allowing combinations causes problems we can create an issue to handle that down the line.~

This PR includes an immediately stale commit which adds support for mixed case keywords; since the specification explicitly states mixed case should not be detected I took that support out.  However, I'm keeping the feature in git history in case we change our minds down the line.

Resolve #11