### PR TITLE
Add support for clauses in proximity search

### DIFF
--- a/grammar/__tests__/uspto.test.js
+++ b/grammar/__tests__/uspto.test.js
@@ -128,4 +128,8 @@ describe('USPTO Grammar', () => {
 		testValidInput('L15 OR "pants"')
 		testValidInput('L15 OR L16')
 	})
+
+	it('should allow proximity clauses to connect compound clauses', () => {
+		testValidInput('(increase$3 or decreas$3 or adjust$3 or chang$3 or adapt$3) near2 (timeout or timer)')
+	})
 })

--- a/grammar/uspto.ne
+++ b/grammar/uspto.ne
@@ -90,13 +90,27 @@ clause ->
 	| booleanClause {% denest %}
 
 nonBooleanClause ->
-	  atomicTerm _ {% denest %}
-	| closedClause _ {% denest %}
-	| proximityClause _ {% denest %}
-	| fieldClause _ {% denest %}
-	| fuzzyClause _ {% denest %}
-	| boostClause _ {% denest %}
-	| lineClause _ {% denest %}
+	  searchClause _ {% denest %}
+	| filterClause _ {% denest %}
+
+###################
+## Filter Clause ##
+# Filter clauses are generally removed from the search string
+# and are used to search things other than the core text.
+# Certain compound clauses (e.g. proximity) need to ignore filter clauses.
+filterClause ->
+	  fieldClause {% denest %}
+	| lineClause {% denest %}
+
+###################
+## Search Clause ##
+# A search clause is used to identify specific terms in some way.
+searchClause ->
+	  atomicTerm {% denest %}
+	| fuzzyClause {% denest %}
+	| boostClause {% denest %}
+	| closedClause {% denest %}
+	| proximityClause {% denest %}
 
 booleanClause -> nonBooleanClause booleanOperator __ clause {% ([left, operator, _, right]) => ({
 	type: 'booleanClause',
@@ -137,7 +151,7 @@ closedClause -> %leftParen _ clause %rightParen {% ([lParen, _, clause, rParen])
 #######################
 ## Proximity Clauses ##
 # clauses that identify pairs of nearby terms
-proximityClause -> atomicTerm _ proximityOperator __ atomicTerm {% ([left, _1, operator, _2, right ]) => ({
+proximityClause -> searchClause _ proximityOperator __ searchClause {% ([left, _1, operator, _2, right ]) => ({
 	type: 'proximityClause',
 	left,
 	operator,


### PR DESCRIPTION
When adding tests based on USPTO provided queries, it became clear that proximity clauses (e.g. ADJ or NEAR) should allow for things like compound statements.  This allows us to parse those kinds of clause.

In order to do this we needed to create two categories of clause: searchClause and filterClause.  Filter clauses are terms that ultimately get removed from the final search string and instead somehow modify the search (e.g. something that would filter to only show documents created on a certain day).

One thing that is not clear, is how the system should handle compound clauses that do not contain search clauses.  Right now a compound clause can contain any type of clause inside of parentheses.  It may not be possible to detect that kind of thing at a parse level.

Issue #10 
Resolves #13 